### PR TITLE
ENH: Add 'start' and additional tasks to Pixi manifest

### DIFF
--- a/.pixi/config.toml
+++ b/.pixi/config.toml
@@ -1,0 +1,1 @@
+run-post-link-scripts = "insecure"

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ export PATH="/root/.pixi/bin:$PATH"
 cd user/
 git clone git@github.com:prashjha/PeriDEM.git
 cd PeriDEM/
-pixi run build
+pixi run test
 ```
 
 ### Future plans

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,10 +26,10 @@ ctest --verbose --test-dir build/
 
 [dependencies]
 cxx-compiler = ">=1.11.0,<2"
-cmake = "<4"
+cmake = ">=4.2.1,<5"
 make = ">=4.4.1,<5"
 vtk = ">=9.5.2,<10"
 yaml-cpp = ">=0.8.0,<0.9"
 metis = ">=5.2.1,<6"
 openmpi = ">=5.0.8,<6"
-gmsh = ">=4.13.1,<5"  # for tests
+gmsh = ">=4.15.0,<5"  # for tests

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,11 +4,9 @@ name = "PeriDEM"
 platforms = ["linux-64", "osx-arm64"]
 version = "v0.2.1"
 
-# Currently can't install, only build?
-# c.f. https://github.com/prashjha/PeriDEM/blob/8f73cbd12fbf8d483bb46670661f9f2641d03c37/README.md?plain=1#L264
 [tasks.build]
+description = "Build PeriDEM from local source"
 cmd = """
-rm -rf build && \
 cmake   -DEnable_Documentation=OFF \
         -DEnable_Tests=ON \
         -DEnable_High_Load_Tests=OFF \
@@ -20,9 +18,24 @@ cmake   -DEnable_Documentation=OFF \
         -S . \
         -B build && \
 cmake build -LH && \
-cmake --build build --clean-first --parallel "$(nproc --ignore=2)" && \
-ctest --verbose --test-dir build/
+cmake --build build --clean-first --parallel "$(nproc --ignore=2)"
 """
+
+[tasks.ctest]
+description = "Run tests with ctest"
+cmd = "ctest --verbose --test-dir ./build/"
+
+[tasks.install-peridem]
+description = "Install PeriDEM under CMAKE_INSTALL_PREFIX defined in build"
+cmd = "cmake --install build"
+
+[tasks.start]
+description = "Build and install PeriDEM"
+depends-on = ["build", "install-peridem"]
+
+[tasks.test]
+description = "Do a clean build of PeriDEM and run ctest tests"
+depends-on = ["build", "ctest"]
 
 [dependencies]
 cxx-compiler = ">=1.11.0,<2"


### PR DESCRIPTION
Follow up to PR #48 

## Proposed Changes

  - Update cmake dependency to allow for CMake policy v4, following support for CMake v4 in PR #48.
  - Separate tasks out in Pixi manifest to allow for running build, testing, and install tasks separately. Add canonical 'start' task to build and install software. Add 'test' task that will do a clean build and run ctests.
* Update task name from 'build' to 'test' in README.
* Remove 'rm' of build directory from 'build' task to allow for potentially skipping files that do not need to be regenerated and to give user slightly more control.

This now provides

```console
$ pixi task list
Tasks that can run on this machine:
-----------------------------------
build, ctest, install-peridem, start, test
Task             Description
build            Build PeriDEM from local source
ctest            Run tests with ctest
install-peridem  Install PeriDEM under CMAKE_INSTALL_PREFIX defined in build
start            Build and install PeriDEM
test             Do a clean build of PeriDEM and run ctest tests
```

and if a user now runs

```
$ pixi run start
```

they will build PeriDEM and get it installed under their Pixi environment. If a developer runs

```
$ pixi run test
```

it will do a clean build of PeriDEM in `./build/` and then run the `ctests` for that build.

## Any background context you want to provide?

This is some suggested extensions for PR #48 to provide some developer ease of use improvements if they chose to use Pixi. These suggestions are **not required** in any way for the JOSS review to advance and are just meant to be a "drive by" PR.