### PR TITLE
Name the parameters isInList actually takes

### DIFF
--- a/src/util/methods.h
+++ b/src/util/methods.h
@@ -257,9 +257,9 @@ inline bool isFree(const uint8_t &i, const unsigned int &dof) {
 
 /*!
  * @brief Find if data is in the list
- * @param tag Tag to search
- * @param tags List of tags
- * @return True True if tag exists
+ * @param i Item to search
+ * @param list Vector of elements
+ * @return True True if item exists
  */
 template <typename T>
 inline bool isInList(const T &i, const std::vector<T> &list) {


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - `isInList` documents `tag` and `tags`, but those are the parameters of `isTagInList` right below it -- the block looks copied from there. The function itself takes `i` and `list`, so Doxygen drops both entries and it renders with no parameters at all
  - comments only, no code touched

```
$ clang++ -Wdocumentation -fsyntax-only -Isrc t.cpp
src/util/methods.h:260:11: warning: parameter 'tag' not found in the function declaration
src/util/methods.h:261:11: warning: parameter 'tags' not found in the function declaration
```

Two warnings before, none after.

## Any background context you want to provide?

The wording is not invented, `addToList` two functions further down already documents the same pair:

```cpp
/*!
 * @brief Add element to the list
 * @param i Item to add
 * @param list Vector of elements
 */
template <typename T>
inline void addToList(const T &i, std::vector<T> &list) {
```

Found while running `-Wdocumentation` across a set of C++ projects. It was the only hit in PeriDEM that is a real mismatch -- the rest of the header uses `@return name description`, which Doxygen handles fine and I left alone